### PR TITLE
Updated the incorrect language identifier

### DIFF
--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,5 +1,5 @@
 # Italiano
-en:
+it:
   label_name: "Sale riunioni"
   label_meeting_date: "Data"
   label_meeting_end_date: "Data Fine"


### PR DESCRIPTION
Some of the labels were coming up in Italian by default. The fix should revert it back to English